### PR TITLE
GsmSS: Use per-slot resources for carrier-bound options

### DIFF
--- a/src/java/com/android/internal/telephony/gsm/GsmServiceStateTracker.java
+++ b/src/java/com/android/internal/telephony/gsm/GsmServiceStateTracker.java
@@ -1667,8 +1667,15 @@ public class GsmServiceStateTracker extends ServiceStateTracker {
      */
     private boolean isOperatorConsideredNonRoaming(ServiceState s) {
         String operatorNumeric = s.getOperatorNumeric();
-        String[] numericArray = mPhone.getContext().getResources().getStringArray(
+        String[] numericArray;
+        int subId = mPhone.getSubId();
+        if (subId >= 0) {
+            numericArray = SubscriptionManager.getResourcesForSubId(mPhone.getContext(),subId)
+                 .getStringArray(com.android.internal.R.array.config_operatorConsideredNonRoaming);
+        } else {
+            numericArray = mPhone.getContext().getResources().getStringArray(
                     com.android.internal.R.array.config_operatorConsideredNonRoaming);
+        }
 
         if (numericArray.length == 0 || operatorNumeric == null) {
             return false;
@@ -1684,8 +1691,16 @@ public class GsmServiceStateTracker extends ServiceStateTracker {
 
     private boolean isOperatorConsideredRoaming(ServiceState s) {
         String operatorNumeric = s.getOperatorNumeric();
-        String[] numericArray = mPhone.getContext().getResources().getStringArray(
+        String[] numericArray;
+        int subId = mPhone.getSubId();
+        if (subId >= 0) {
+            numericArray = SubscriptionManager.getResourcesForSubId(mPhone.getContext(),subId)
+                .getStringArray(
                     com.android.internal.R.array.config_sameNamedOperatorConsideredRoaming);
+        } else {
+            numericArray = mPhone.getContext().getResources().getStringArray(
+                    com.android.internal.R.array.config_sameNamedOperatorConsideredRoaming);
+        }
 
         if (numericArray.length == 0 || operatorNumeric == null) {
             return false;


### PR DESCRIPTION
The decision of whether an MVNO operator is roaming or not comes from
an mcc/mnc-specific resource. Relying on the global system resources
to provide the appropriate result for each of the slots on a multi-SIM
device is just wrong, since each SIM will have (and need) its own
separate preferences and arrays of compatible/blocked carriers.

Ref CYNGNOS-2534, CYNGNOS-3190

Change-Id: If3b45a4a4702cf45bc1d965e26c8df7ef3ff783b